### PR TITLE
Add .gitignore with dataset and virtualenv exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+
+data_cache/
+your_dataset/
+
+# Virtual environment
+venv/


### PR DESCRIPTION
## Summary
- add a project-wide `.gitignore` that skips Python build artifacts
- ignore dataset directories including `data_cache/` and example `your_dataset/`
- exclude virtual environments

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867dcc896148326bccb8e1dc07b32d2